### PR TITLE
Fix gh workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,12 @@ jobs:
           git config user.email "<>"
       - name: Commit
         run: |
-          # Stage the file, commit and push
-          git add README.md
-          git commit -m "Update README.md."
-          git push origin main
+          if [[ -n $(git status -s) ]]; then
+            # If changes exist, stage the file, commit and push
+            git add README.md
+            git commit -m "Update README.md."
+            git push origin main
+          else
+            # No changes, skip commit and push.
+            echo "No changes to commit. Skipping commit and push."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .cache
 .settings
 .vscode
+package-lock.json


### PR DESCRIPTION
This PR:
- Fixes the gh workflow commit step to run conditionally. It will now run only when there are changes to commit, preventing failed commits when there are no changes.
- Adds `package-lock.json` to `.gitignore` file.
